### PR TITLE
feat: radio 공통 컴포넌트 추가

### DIFF
--- a/src/shared/ui/Radio.tsx
+++ b/src/shared/ui/Radio.tsx
@@ -1,0 +1,83 @@
+import React, { forwardRef } from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/shared/lib/util/utils';
+
+const radioVariants = cva('relative flex items-center', {
+  variants: {
+    size: {
+      sm: 'gap-2 text-sm',
+      md: 'gap-3 text-base',
+      lg: 'gap-4 text-lg',
+    },
+    disabled: {
+      true: 'opacity-50 cursor-not-allowed',
+    },
+  },
+  defaultVariants: {
+    size: 'md',
+    disabled: false,
+  },
+});
+
+export interface RadioProps
+  extends Omit<
+      React.InputHTMLAttributes<HTMLInputElement>,
+      'size' | 'disabled'
+    >,
+    VariantProps<typeof radioVariants> {
+  label?: string;
+  containerClassName?: string;
+  disabled?: boolean;
+}
+
+export const Radio = forwardRef<HTMLInputElement, RadioProps>(
+  ({ className, size, label, disabled, containerClassName, ...props }, ref) => {
+    const radioSize = {
+      sm: 'w-4 h-4',
+      md: 'w-5 h-5',
+      lg: 'w-6 h-6',
+    };
+
+    const dotSize = {
+      sm: 'w-2 h-2',
+      md: 'w-2.5 h-2.5',
+      lg: 'w-3 h-3',
+    };
+
+    return (
+      <label
+        className={cn(radioVariants({ size, disabled }), containerClassName)}
+      >
+        <div className="relative flex items-center justify-center">
+          <input
+            type="radio"
+            ref={ref}
+            disabled={disabled}
+            className={cn(
+              'peer appearance-none border border-gray-30 rounded-full',
+              'checked:border-[#FF9320] checked:border-2',
+              'focus:outline-none focus:ring-2 focus:ring-[#FF9320]/50',
+              'disabled:border-gray-30 disabled:bg-gray-10',
+              radioSize[size || 'md'],
+              className
+            )}
+            {...props}
+          />
+          <div
+            className={cn(
+              'absolute rounded-full bg-[#FF9320] opacity-0 peer-checked:opacity-100 pointer-events-none',
+              dotSize[size || 'md']
+            )}
+          ></div>
+        </div>
+        {label && (
+          <span className={cn('text-gray-90', disabled ? 'text-gray-50' : '')}>
+            {label}
+          </span>
+        )}
+      </label>
+    );
+  }
+);
+
+Radio.displayName = 'Radio';


### PR DESCRIPTION
## 📋 작업 내용
Radio 컴포넌트 구현 및 관련 기능 추가
- 다양한 크기(sm, md, lg)를 지원하는 Radio 컴포넌트 개발
- 하이브리드 방식의 사이즈 설정 적용 (중앙 집중식 정의 + 컴포넌트 내부 사용)
- 비활성화(disabled) 상태 스타일링 구현
- 체크 상태에 따른 시각적 피드백 추가
- 접근성을 고려한 레이블 연결 기능

## 📄 기타
- FSD 아키텍처에 맞추어 shared/ui 폴더에 컴포넌트 추가
- 버튼, 인풋과 동일한 디자인 시스템 규칙 준수
- 향후 다른 폼 컴포넌트에서도 재사용 가능한 사이즈 정의 구조 도입